### PR TITLE
feat: Add support for windows arm64 prebuilt-boost

### DIFF
--- a/.github/workflows/build-boost.yml
+++ b/.github/workflows/build-boost.yml
@@ -35,6 +35,15 @@ jobs:
             COMPILER: gcc
             LINK: 'static+shared'
             ARCH: x86
+          # Windows 11 ARM
+          - os: windows-11-arm
+            COMPILER: msvc
+            LINK: 'static'
+            ARCH: arm64
+          - os: windows-11-arm
+            COMPILER: msvc
+            LINK: 'shared'
+            ARCH: arm64
           # Windows Server 2025
           - os: windows-2025
             COMPILER: msvc
@@ -124,36 +133,36 @@ jobs:
       # Install python
       - name: Setup python 3.8
         uses: actions/setup-python@v5
-        if: ${{ (runner.os != 'Windows' || matrix.COMPILER != 'msvc' || matrix.LINK != 'shared') && matrix.os != 'macos-14' && matrix.os != 'macos-15' }}
+        if: ${{ (runner.os != 'Windows' || matrix.COMPILER != 'msvc' || matrix.LINK != 'shared') && matrix.os != 'macos-14' && matrix.os != 'macos-15' && matrix.os != 'windows-11-arm' }}
         with:
           python-version: '3.8'
       - name: Add python 3.8 to user-config
         working-directory: boost/tools/build/src
-        if: ${{ (runner.os != 'Windows' || matrix.COMPILER != 'msvc' || matrix.LINK != 'shared') && matrix.os != 'macos-14' && matrix.os != 'macos-15' }}
+        if: ${{ (runner.os != 'Windows' || matrix.COMPILER != 'msvc' || matrix.LINK != 'shared') && matrix.os != 'macos-14' && matrix.os != 'macos-15' && matrix.os != 'windows-11-arm' }}
         shell: bash
         run: |
           VAR="using python : 3.8 : $Python_ROOT_DIR ;"
           echo ${VAR//\\/\/} >> user-config.jam
       - name: Setup python 3.9
         uses: actions/setup-python@v5
-        if: ${{ (runner.os != 'Windows' || matrix.COMPILER != 'msvc' || matrix.LINK != 'shared') && matrix.os != 'macos-14' && matrix.os != 'macos-15' }}
+        if: ${{ (runner.os != 'Windows' || matrix.COMPILER != 'msvc' || matrix.LINK != 'shared') && matrix.os != 'macos-14' && matrix.os != 'macos-15' && matrix.os != 'windows-11-arm' }}
         with:
           python-version: '3.9'
       - name: Add python 3.9 to user-config
         working-directory: boost/tools/build/src
-        if: ${{ (runner.os != 'Windows' || matrix.COMPILER != 'msvc' || matrix.LINK != 'shared') && matrix.os != 'macos-14' && matrix.os != 'macos-15' }}
+        if: ${{ (runner.os != 'Windows' || matrix.COMPILER != 'msvc' || matrix.LINK != 'shared') && matrix.os != 'macos-14' && matrix.os != 'macos-15' && matrix.os != 'windows-11-arm' }}
         shell: bash
         run: |
           VAR="using python : 3.9 : $Python_ROOT_DIR ;"
           echo ${VAR//\\/\/} >> user-config.jam
       - name: Setup python 3.10
         uses: actions/setup-python@v5
-        if: ${{ (runner.os != 'Windows' || matrix.COMPILER != 'msvc' || matrix.LINK != 'shared') && matrix.os != 'macos-14' && matrix.os != 'macos-15' }}
+        if: ${{ (runner.os != 'Windows' || matrix.COMPILER != 'msvc' || matrix.LINK != 'shared') && matrix.os != 'macos-14' && matrix.os != 'macos-15' && matrix.os != 'windows-11-arm' }}
         with:
           python-version: '3.10'
       - name: Add python 3.10 to user-config
         working-directory: boost/tools/build/src
-        if: ${{ (runner.os != 'Windows' || matrix.COMPILER != 'msvc' || matrix.LINK != 'shared') && matrix.os != 'macos-14' && matrix.os != 'macos-15' }}
+        if: ${{ (runner.os != 'Windows' || matrix.COMPILER != 'msvc' || matrix.LINK != 'shared') && matrix.os != 'macos-14' && matrix.os != 'macos-15' && matrix.os != 'windows-11-arm' }}
         shell: bash
         run: |
           VAR="using python : 3.10 : $Python_ROOT_DIR ;"
@@ -209,13 +218,21 @@ jobs:
         run: ./bootstrap.sh
         working-directory: boost
       - name: Build windows msvc (static)
-        if: ${{ runner.os == 'Windows' && matrix.COMPILER == 'msvc' && matrix.LINK == 'static' }}
+        if: ${{ runner.os == 'Windows' && matrix.COMPILER == 'msvc' && matrix.LINK == 'static' && matrix.os != 'windows-11-arm' }}
         #run: .\b2.exe install --build-dir='tmp' --prefix='.' runtime-link='static,shared' link='static,shared' variant='release,debug' address-model='32,64' -j4 msvc stage
         run: .\b2.exe install --build-dir='tmp' --prefix='.' variant='release,debug' address-model='32,64' link=${{matrix.LINK}} python='3.8,3.9,3.10,3.11,3.12,3.13' -j4 msvc stage
         working-directory: boost
       - name: Build windows msvc (shared) without python
-        if: ${{ runner.os == 'Windows' && matrix.COMPILER == 'msvc' && matrix.LINK == 'shared' }}
+        if: ${{ runner.os == 'Windows' && matrix.COMPILER == 'msvc' && matrix.LINK == 'shared' && matrix.os != 'windows-11-arm' }}
         run: .\b2.exe install --build-dir='tmp' --prefix='.' --without-python variant='release,debug' address-model='32,64' link=${{matrix.LINK}} -j4 msvc stage
+        working-directory: boost
+      - name: Build windows arm64 (static)
+        if: ${{ matrix.os == 'windows-11-arm' && matrix.COMPILER == 'msvc' && matrix.LINK == 'static' }}
+        run: .\b2.exe install --build-dir=tmp --prefix=. architecture=arm address-model=64 variant=release,debug link=${{ matrix.LINK }} python=3.11,3.12,3.13 --without-mpi --without-graph_parallel --without-histogram --without-coroutine context-impl=winfib -j4 toolset=msvc pch=off stage
+        working-directory: boost
+      - name: Build windows arm64 (shared) without python
+        if: ${{ matrix.os == 'windows-11-arm' && matrix.COMPILER == 'msvc' && matrix.LINK == 'shared' }}
+        run: .\b2.exe install --build-dir=tmp --prefix=. --without-python architecture=arm address-model=64 variant=release,debug link=${{ matrix.LINK }} --without-mpi --without-graph_parallel --without-histogram --without-coroutine context-impl=winfib -j4 toolset=msvc pch=off stage
         working-directory: boost
       - name: Build windows mingw
         if: ${{ runner.os == 'Windows' && matrix.COMPILER == 'mingw' }}

--- a/.github/workflows/build-boost.yml
+++ b/.github/workflows/build-boost.yml
@@ -39,11 +39,11 @@ jobs:
           - os: windows-11-arm
             COMPILER: msvc
             LINK: 'static'
-            ARCH: arm64
+            ARCH: aarch64
           - os: windows-11-arm
             COMPILER: msvc
             LINK: 'shared'
-            ARCH: arm64
+            ARCH: aarch64
           # Windows Server 2025
           - os: windows-2025
             COMPILER: msvc

--- a/manifest-creator/index.ts
+++ b/manifest-creator/index.ts
@@ -81,6 +81,7 @@ async function main(): Promise<void> {
                     const split = d.name
                         .substring(0, d.name.indexOf('.tar.gz'))
                         .split('-');
+                    
                     return {
                         filename: d.name,
                         platform: split[2].replace(

--- a/manifest-creator/index.ts
+++ b/manifest-creator/index.ts
@@ -81,7 +81,6 @@ async function main(): Promise<void> {
                     const split = d.name
                         .substring(0, d.name.indexOf('.tar.gz'))
                         .split('-');
-                    const arm_build = split[4] === 'arm'; 
                     return {
                         filename: d.name,
                         platform: split[2].replace(

--- a/manifest-creator/index.ts
+++ b/manifest-creator/index.ts
@@ -14,7 +14,7 @@ type PlatformVersion =
     | '12'
     | '13';
 type Toolset = 'gcc' | 'msvc' | 'mingw' | 'clang';
-type Arch = 'x86' | 'aarch64';
+type Arch = 'x86' | 'aarch64' | 'arm64';
 type Link = 'static' | 'shared' | 'static+shared';
 
 interface File {

--- a/manifest-creator/index.ts
+++ b/manifest-creator/index.ts
@@ -81,7 +81,7 @@ async function main(): Promise<void> {
                     const split = d.name
                         .substring(0, d.name.indexOf('.tar.gz'))
                         .split('-');
-
+                    const arm_build = split[4] === 'arm'; 
                     return {
                         filename: d.name,
                         platform: split[2].replace(
@@ -94,7 +94,7 @@ async function main(): Promise<void> {
                             (split.length >= 6 && (split[5] as Link)) ||
                             undefined,
                         arch:
-                            (split.length >= 7 && (split[6] as Arch)) ||
+                            (split.length >= 7 && (split[arm_build ? 7 : 6] as Arch)) ||
                             undefined,
                         download_url: d.browser_download_url,
                     };

--- a/manifest-creator/index.ts
+++ b/manifest-creator/index.ts
@@ -14,7 +14,7 @@ type PlatformVersion =
     | '12'
     | '13';
 type Toolset = 'gcc' | 'msvc' | 'mingw' | 'clang';
-type Arch = 'x86' | 'aarch64' | 'arm64';
+type Arch = 'x86' | 'aarch64';
 type Link = 'static' | 'shared' | 'static+shared';
 
 interface File {
@@ -94,7 +94,7 @@ async function main(): Promise<void> {
                             (split.length >= 6 && (split[5] as Link)) ||
                             undefined,
                         arch:
-                            (split.length >= 7 && (split[arm_build ? 7 : 6] as Arch)) ||
+                            (split.length >= 7 && (split[6] as Arch)) ||
                             undefined,
                         download_url: d.browser_download_url,
                     };

--- a/manifest-creator/index.ts
+++ b/manifest-creator/index.ts
@@ -81,7 +81,7 @@ async function main(): Promise<void> {
                     const split = d.name
                         .substring(0, d.name.indexOf('.tar.gz'))
                         .split('-');
-                    
+
                     return {
                         filename: d.name,
                         platform: split[2].replace(

--- a/versions-manifest.json
+++ b/versions-manifest.json
@@ -1971,5 +1971,118 @@
                 "download_url": "https://github.com/MarkusJx/prebuilt-boost/releases/download/1.88.0/boost-1.88.0-windows-2025-msvc-static-x86.tar.gz"
             }
         ]
+    },
+    {
+        "version": "1.89.0",
+        "files": [
+            {
+                "filename": "boost-1.89.0-macos-13-clang-static+shared-x86.tar.gz",
+                "platform": "macos",
+                "platform_version": "13",
+                "toolset": "clang",
+                "link": "static+shared",
+                "arch": "x86",
+                "download_url": "https://github.com/MarkusJx/prebuilt-boost/releases/download/1.89.0/boost-1.89.0-macos-13-clang-static%2Bshared-x86.tar.gz"
+            },
+            {
+                "filename": "boost-1.89.0-macos-14-clang-static+shared-aarch64.tar.gz",
+                "platform": "macos",
+                "platform_version": "14",
+                "toolset": "clang",
+                "link": "static+shared",
+                "arch": "aarch64",
+                "download_url": "https://github.com/MarkusJx/prebuilt-boost/releases/download/1.89.0/boost-1.89.0-macos-14-clang-static%2Bshared-aarch64.tar.gz"
+            },
+            {
+                "filename": "boost-1.89.0-macos-15-clang-static+shared-aarch64.tar.gz",
+                "platform": "macos",
+                "platform_version": "15",
+                "toolset": "clang",
+                "link": "static+shared",
+                "arch": "aarch64",
+                "download_url": "https://github.com/MarkusJx/prebuilt-boost/releases/download/1.89.0/boost-1.89.0-macos-15-clang-static%2Bshared-aarch64.tar.gz"
+            },
+            {
+                "filename": "boost-1.89.0-ubuntu-22.04-gcc-static+shared-aarch64.tar.gz",
+                "platform": "linux",
+                "platform_version": "22.04",
+                "toolset": "gcc",
+                "link": "static+shared",
+                "arch": "aarch64",
+                "download_url": "https://github.com/MarkusJx/prebuilt-boost/releases/download/1.89.0/boost-1.89.0-ubuntu-22.04-gcc-static%2Bshared-aarch64.tar.gz"
+            },
+            {
+                "filename": "boost-1.89.0-ubuntu-22.04-gcc-static+shared-x86.tar.gz",
+                "platform": "linux",
+                "platform_version": "22.04",
+                "toolset": "gcc",
+                "link": "static+shared",
+                "arch": "x86",
+                "download_url": "https://github.com/MarkusJx/prebuilt-boost/releases/download/1.89.0/boost-1.89.0-ubuntu-22.04-gcc-static%2Bshared-x86.tar.gz"
+            },
+            {
+                "filename": "boost-1.89.0-ubuntu-24.04-gcc-static+shared-x86.tar.gz",
+                "platform": "linux",
+                "platform_version": "24.04",
+                "toolset": "gcc",
+                "link": "static+shared",
+                "arch": "x86",
+                "download_url": "https://github.com/MarkusJx/prebuilt-boost/releases/download/1.89.0/boost-1.89.0-ubuntu-24.04-gcc-static%2Bshared-x86.tar.gz"
+            },
+            {
+                "filename": "boost-1.89.0-windows-11-arm-msvc-shared-x86.tar.gz",
+                "platform": "windows",
+                "platform_version": "11",
+                "toolset": "arm",
+                "link": "msvc",
+                "arch": "shared",
+                "download_url": "https://github.com/MarkusJx/prebuilt-boost/releases/download/1.89.0/boost-1.89.0-windows-11-arm-msvc-shared-x86.tar.gz"
+            },
+            {
+                "filename": "boost-1.89.0-windows-11-arm-msvc-static-x86.tar.gz",
+                "platform": "windows",
+                "platform_version": "11",
+                "toolset": "arm",
+                "link": "msvc",
+                "arch": "static",
+                "download_url": "https://github.com/MarkusJx/prebuilt-boost/releases/download/1.89.0/boost-1.89.0-windows-11-arm-msvc-static-x86.tar.gz"
+            },
+            {
+                "filename": "boost-1.89.0-windows-2022-msvc-shared-x86.tar.gz",
+                "platform": "windows",
+                "platform_version": "2022",
+                "toolset": "msvc",
+                "link": "shared",
+                "arch": "x86",
+                "download_url": "https://github.com/MarkusJx/prebuilt-boost/releases/download/1.89.0/boost-1.89.0-windows-2022-msvc-shared-x86.tar.gz"
+            },
+            {
+                "filename": "boost-1.89.0-windows-2022-msvc-static-x86.tar.gz",
+                "platform": "windows",
+                "platform_version": "2022",
+                "toolset": "msvc",
+                "link": "static",
+                "arch": "x86",
+                "download_url": "https://github.com/MarkusJx/prebuilt-boost/releases/download/1.89.0/boost-1.89.0-windows-2022-msvc-static-x86.tar.gz"
+            },
+            {
+                "filename": "boost-1.89.0-windows-2025-msvc-shared-x86.tar.gz",
+                "platform": "windows",
+                "platform_version": "2025",
+                "toolset": "msvc",
+                "link": "shared",
+                "arch": "x86",
+                "download_url": "https://github.com/MarkusJx/prebuilt-boost/releases/download/1.89.0/boost-1.89.0-windows-2025-msvc-shared-x86.tar.gz"
+            },
+            {
+                "filename": "boost-1.89.0-windows-2025-msvc-static-x86.tar.gz",
+                "platform": "windows",
+                "platform_version": "2025",
+                "toolset": "msvc",
+                "link": "static",
+                "arch": "x86",
+                "download_url": "https://github.com/MarkusJx/prebuilt-boost/releases/download/1.89.0/boost-1.89.0-windows-2025-msvc-static-x86.tar.gz"
+            }
+        ]
     }
 ]


### PR DESCRIPTION
PR Description:

* The adoption of Windows on ARM (WoA) devices is steadily increasing, yet many applications are still not available for this platform.
* GitHub Actions now offer native CI runners for Windows on ARM devices (windows-11-arm), enabling automated builds and testing.
* This PR introduces support for prebuilt boost on Windows ARM64, improving accessibility for developers and end users on this emerging platform.
* Currently, few targets from Boost such as mpi, graph_parallel, histogram, coroutine are not supported for Windows on ARM. So these targets are currently skipped during the build.
* Additionally switching on PCH(precompiled headers) option leads to out of heap memory usage during compilation, so switching off this option is necessary to get a successful build.